### PR TITLE
Preserve timestamp in session.clear() + upgrade guice

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -48,7 +48,7 @@ dependencies {
   compile('io.netty:netty:3.10.6.Final')
   compile('org.slf4j:slf4j-api:1.7.25')
   compile('org.slf4j:slf4j-log4j12:1.7.25')
-  compile('org.yaml:snakeyaml:1.19')
+  compile('org.yaml:snakeyaml:1.20')
   compile('net.spy:spymemcached:2.12.3')
   compile('com.thoughtworks.xstream:xstream:1.4.10') {transitive = false}
   compile('xmlpull:xmlpull:1.1.3.4d_b4_min')

--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -263,8 +263,10 @@ public class Scope {
         }
 
         public void clear() {
+            String timeStamp = data.get(TS_KEY);
             change();
             data.clear();
+            put(TS_KEY, timeStamp);
         }
 
         /**

--- a/framework/test/play/mvc/SessionTest.java
+++ b/framework/test/play/mvc/SessionTest.java
@@ -4,8 +4,8 @@ import org.junit.Test;
 import play.PlayBuilder;
 import play.mvc.Scope.Session;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static play.mvc.Scope.Session.TS_KEY;
 
 public class SessionTest {
 
@@ -31,9 +31,19 @@ public class SessionTest {
         session.changed = false;
         session.remove("username");
         assertTrue(session.changed);
+    }
 
+    @Test
+    public void clear() throws Exception {
+        Session session = new Session();
         session.changed = false;
+        session.put("foo", "bar");
+        session.put(TS_KEY, "12/01/2017");
+
         session.clear();
+
         assertTrue(session.changed);
+        assertEquals(1, session.data.size());
+        assertEquals("12/01/2017", session.data.get(TS_KEY));
     }
 }

--- a/guice/build.gradle
+++ b/guice/build.gradle
@@ -2,7 +2,7 @@ dependencies {
   compile project(':framework')
   testCompile project(':framework').sourceSets.test.compileClasspath
 
-  compile('com.google.inject:guice:4.1-java9')
+  compile('com.google.inject:guice:4.2.0')
   compile('com.google.inject.extensions:guice-multibindings:4.1.0') {transitive = false}
   compile('aopalliance:aopalliance:1.0') {transitive = false}
 }


### PR DESCRIPTION
Preserve timestamp in session.clear() as otherwise new session will be created in CookieSessionStore.restore() and all the data added after clearing session will be lost.

In addition, upgrade guice to 4.2.0, which already has full java9 support.