### PR TITLE
Make the `i18n` tag to work

### DIFF
--- a/framework/src/tags/i18n.tag
+++ b/framework/src/tags/i18n.tag
@@ -6,10 +6,8 @@ if (_keys) {
 }
 js_messages=new com.google.gson.Gson().toJson(ymessages);
 }%
-#{if !_noScriptTag}
 <script type="text/javascript">
-#{/if}
-var i18nMessages = ${js_messages};
+var i18nMessages = ${js_messages.raw()};
 
 /**
  * Fixme : only parse single char formatters eg. %s
@@ -41,6 +39,4 @@ var i18n = function(code) {
     }
     return message;
 };
-#{if !_noScriptTag}
 </script>
-#{/if}


### PR DESCRIPTION
We had to make these changes for to et the `i18n` tag to work.

With the ifs around the `<script>` tags we got "unclosed script tag" as a runtime error.

Without the `.raw()` we found the double quotes in the bit of JS were all escaped (i.e. `\"` instead of `"`).

No test case, sorry.