### PR TITLE
Stops resetting of Session cookie when ID has been set

### DIFF
--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -240,7 +240,7 @@ public class Scope {
          */
         public boolean isEmpty() {
             for (String key : data.keySet()) {
-                if (!TS_KEY.equals(key) && !UA_KEY.equals(key) && !ID_KEY.equals(key)) {
+                if (!TS_KEY.equals(key) && !UA_KEY.equals(key)) {
                     return false;
                 }
             }

--- a/framework/test/play/mvc/ScopeTest.java
+++ b/framework/test/play/mvc/ScopeTest.java
@@ -135,13 +135,6 @@ public class ScopeTest {
     }
 
     @Test
-    public void sessionWithOnlyId_isEmpty() {
-        Session session = new Session();
-        assertThat(session.getId()).isNotEmpty();
-        assertThat(session.isEmpty()).isTrue();
-    }
-
-    @Test
     public void flashErrorFormat() {
         Flash flash = new Flash();
         flash.error("Your name is %s", "Hello");


### PR DESCRIPTION
We're building new functionality in our application that leverages the session ID. We are encountering an issue where the session ID is unnecessarily being reset and therefore session data is inconsistent.
Therefore I opened this PR to revert the change to consider the session empty even if ID is set. Let me know if this is ok or not.