### PR TITLE
Do not expose Apache's commons-lang v2

### DIFF
--- a/fastergt/build.gradle
+++ b/fastergt/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   implementation project(':framework')
   implementation('org.eclipse.jdt:org.eclipse.jdt.core:3.30.0') {transitive = false}
+  implementation('commons-lang:commons-lang:2.6')
   testImplementation project(':framework').sourceSets.test.compileClasspath
 }
 

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   api('org.apache.commons:commons-email:1.5') {transitive = false}
   api('commons-fileupload:commons-fileupload:1.4')
   api('commons-io:commons-io:2.11.0')
-  api('commons-lang:commons-lang:2.6')
+  implementation('commons-lang:commons-lang:2.6')
   api('commons-logging:commons-logging:1.2')
   api('com.h2database:h2:1.4.200')
   implementation('javax.activation:activation:1.1.1')

--- a/pdf/build.gradle
+++ b/pdf/build.gradle
@@ -19,6 +19,7 @@ dependencies {
   testImplementation project(':framework').sourceSets.test.compileClasspath
   testImplementation('org.mockito:mockito-core:4.8.0')
 
+  implementation('commons-lang:commons-lang:2.6')
   thirdParty("org.xhtmlrenderer:flying-saucer-core:$FLYING_SOURCER_VERSION")
   implementation("org.xhtmlrenderer:flying-saucer-pdf:$FLYING_SOURCER_VERSION") {
     exclude group: 'org.xhtmlrenderer', module: 'flying-saucer-core'


### PR DESCRIPTION
I want to force our code base to only use `commons-lang3`, but RePlay exposes it.

I do not think it is required to be exposed, so I took a stab at hiding it in RePlay.