### PR TITLE
Remove ezmorph dependency

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -25,7 +25,6 @@ dependencies {
   implementation('jaxen:jaxen:1.2.0')
   implementation('ch.qos.reload4j:reload4j:1.2.22')
   implementation('org.ehcache:ehcache:3.10.1')
-  implementation('net.sf.ezmorph:ezmorph:1.0.6')
   implementation('net.sf.jsr107cache:jsr107cache:1.1')
   api('net.sf.oval:oval:3.2.1')
   api('org.codehaus.groovy:groovy:3.0.12')


### PR DESCRIPTION
All tests still run. I did not see the dependency used anywhere in the code (no `import` from the package).

Did no see any usage in Play1 either (weird?) -- maybe this is used only at runtime, or from Groovy?

For some nice 90s vibes have a look at the webpage:

https://ezmorph.sourceforge.net/dependencies.html

It seems ezmorph is not maintained since 2008.