### PR TITLE
Remove jsr107cache dependency

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -26,7 +26,6 @@ dependencies {
   implementation('ch.qos.reload4j:reload4j:1.2.22')
   implementation('org.ehcache:ehcache:3.10.1')
   implementation('net.sf.ezmorph:ezmorph:1.0.6')
-  implementation('net.sf.jsr107cache:jsr107cache:1.1')
   api('net.sf.oval:oval:3.2.1')
   api('org.codehaus.groovy:groovy:3.0.12')
   api('org.codehaus.groovy:groovy-dateutil:3.0.12')


### PR DESCRIPTION
Removed it and all tests still run green.

It seems to be a package that was used before the `javax.cache:cache-api` is part of Java's std lib.

Last change to this project was in January 2009.

More info:

* https://sourceforge.net/projects/jsr107cache/
* https://github.com/jsr107/jsr107spec

It seems this package was needed by EHCache, which currently depends on `javax.cache:cache-api:1.1.0`.
