### PR TITLE
Remove more dependencies

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -2,8 +2,6 @@ dependencies {
   api('com.google.code.findbugs:jsr305:3.0.2')
   implementation('io.github.classgraph:classgraph:4.8.149')
   api('com.zaxxer:HikariCP:5.0.1')
-  implementation('org.ow2.asm:asm:9.3')
-  api('cglib:cglib:3.3.0') {transitive = false}
   api('com.google.code.gson:gson:2.9.1')
   api('com.jamonapi:jamon:2.82') {transitive = false}
   implementation('com.ning:async-http-client:1.9.40') {
@@ -18,10 +16,8 @@ dependencies {
   api('commons-lang:commons-lang:2.6')
   api('commons-logging:commons-logging:1.2')
   api('com.h2database:h2:1.4.200')
-  implementation('javax.activation:activation:1.1.1')
   api('javax.mail:mail:1.4.7')
   api('javax.inject:javax.inject:1')
-  api('javax.validation:validation-api:2.0.1.Final')
   implementation('jaxen:jaxen:1.2.0')
   implementation('ch.qos.reload4j:reload4j:1.2.22')
   implementation('org.ehcache:ehcache:3.10.1')
@@ -35,10 +31,7 @@ dependencies {
   api('org.hibernate:hibernate-core:5.6.11.Final')
   api('org.hibernate.common:hibernate-commons-annotations:5.1.2.Final')
   api('org.hibernate:hibernate-validator:7.0.4.Final')
-  implementation('org.jboss.logging:jboss-logging:3.5.0.Final')
-  implementation('org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.1.1.Final')
   api('javax.persistence:javax.persistence-api:2.2')
-  implementation('com.fasterxml:classmate:1.5.1')
   implementation('org.hibernate:hibernate-ehcache:5.6.11.Final') {transitive = false}
   api('io.netty:netty:3.10.6.Final')
   api('org.slf4j:slf4j-api:2.0.0')
@@ -46,7 +39,6 @@ dependencies {
   api('org.slf4j:jul-to-slf4j:2.0.0')
   api('org.yaml:snakeyaml:1.31')
   api('net.spy:spymemcached:2.12.3')
-  implementation('xmlpull:xmlpull:1.1.3.4d_b4_min')
 
   testImplementation('junit:junit:4.13.2')
   testImplementation('org.mockito:mockito-core:4.8.0')


### PR DESCRIPTION
I found some more dependencies that seemed to be unused in RePlay itself and in our code base as well. See the changes to know what.

All tests still run green.

Sure this may break code of projects using RePlay, but they can easily add the library to their own dependency specification (which I consider the correct thing to do in this case: why should a framework dictate the choice?).