### PR TITLE
Make RePlay more modular

### DIFF
--- a/framework/src/play/Play.java
+++ b/framework/src/play/Play.java
@@ -139,11 +139,7 @@ public class Play {
    * @param id The framework id to use
    */
   public void init(String id) {
-    Injector.setBeanSource(beanSource);
-    Play.usePrecompiled = "true".equals(System.getProperty("precompiled", "false"));
-    Play.id = id;
-    Play.started = false;
-    Play.applicationPath = new File(System.getProperty("user.dir"));
+    setupBase();
     readConfiguration();
     new PlayLoggingSetup().init();
     logger.info("Starting {}", applicationPath.getAbsolutePath());
@@ -161,16 +157,13 @@ public class Play {
   }
 
   /**
-   * Minimalistic initialization of the framework (no modules, no plugins)
+   * Minimalistic initialization of the framework; allowing DIY-initialization
+   * (no modules, no plugins from .plugins file, no routes from routes file, no config file)
    *
    * @param id The framework id to use
    */
   public void minimalInit(String id) {
-    Injector.setBeanSource(beanSource);
-    Play.usePrecompiled = "true".equals(System.getProperty("precompiled", "false"));
-    Play.id = id;
-    Play.started = false;
-    Play.applicationPath = new File(System.getProperty("user.dir"));
+    setupBase();
     new PlayLoggingSetup().init();
     logger.info("Starting {}", applicationPath.getAbsolutePath());
     setupTmpDir();
@@ -178,6 +171,14 @@ public class Play {
     setupAppRoot();
 
     Play.invoker = new Invoker();
+  }
+
+  private void setupBase() {
+    Injector.setBeanSource(beanSource);
+    Play.usePrecompiled = "true".equals(System.getProperty("precompiled", "false"));
+    Play.id = id;
+    Play.started = false;
+    Play.applicationPath = new File(System.getProperty("user.dir"));
   }
 
   private static void setupTmpDir() {

--- a/framework/src/play/mvc/Router.java
+++ b/framework/src/play/mvc/Router.java
@@ -85,16 +85,19 @@ public class Router {
         instance.setRoutes(emptyList());
     }
 
-    public static void resetForTests(List<Route> routes) {
-        instance.setRoutes(routes);
+    /**
+     * Parse the routes file and load the routing definitions. This is called at normal startup.
+     */
+    private static void load() {
+        load(new RoutesParser().parse(Play.routes));
+        lastLoading = System.currentTimeMillis();
     }
 
     /**
-     * Parse the routes file. This is called at startup.
+     * Load the routing definitions.
      */
-    private static void load() {
-        instance.setRoutes(new RoutesParser().parse(Play.routes));
-        lastLoading = System.currentTimeMillis();
+    public static void load(List<Route> routes) {
+        instance.setRoutes(routes);
     }
 
     /**

--- a/framework/src/play/mvc/Router.java
+++ b/framework/src/play/mvc/Router.java
@@ -60,7 +60,20 @@ public class Router {
         return instance.routes;
     }
 
-    private void setRoutes(List<Route> routes) {
+    /**
+     * Parse the routes file into the routing definitions. Install those definitions in the Router.
+     *
+     * This is called at normal startup.
+     */
+    private static void loadRoutesFromFile() {
+        instance.setRoutes(new RoutesParser().parse(Play.routes));
+        lastLoading = System.currentTimeMillis();
+    }
+
+    /**
+     * Replace routes with provided route definitions.
+     */
+    public void setRoutes(List<Route> routes) {
         actionRoutesCache.clear();
         this.routes.clear();
         parameterlessRoutes.clear();
@@ -83,21 +96,6 @@ public class Router {
 
     public static void clearForTests() {
         instance.setRoutes(emptyList());
-    }
-
-    /**
-     * Parse the routes file and load the routing definitions. This is called at normal startup.
-     */
-    private static void load() {
-        load(new RoutesParser().parse(Play.routes));
-        lastLoading = System.currentTimeMillis();
-    }
-
-    /**
-     * Load the routing definitions.
-     */
-    public static void load(List<Route> routes) {
-        instance.setRoutes(routes);
     }
 
     /**
@@ -127,11 +125,11 @@ public class Router {
             return;
         }
         if (Play.routes.lastModified() > lastLoading) {
-            load();
+            loadRoutesFromFile();
         } else {
             for (VirtualFile file : Play.modulesRoutes.values()) {
                 if (file.lastModified() > lastLoading) {
-                    load();
+                    loadRoutesFromFile();
                     return;
                 }
             }

--- a/framework/test/play/plugins/PluginCollectionTest.java
+++ b/framework/test/play/plugins/PluginCollectionTest.java
@@ -74,7 +74,7 @@ public class PluginCollectionTest {
     @Test
     public void skipsDuplicatePlugins() {
         PluginCollection pc = spy(new PluginCollection());
-        when(pc.loadPlayPluginDescriptors())
+        when(pc.getPlayPluginFileUrls())
                 .thenReturn(asList(getClass().getResource("custom-play.plugins"), getClass().getResource("custom-play.plugins.duplicate")));
         pc.loadPlugins();
         assertThat(pc.getAllPlugins()).containsExactly(pc.getPluginInstance(PlayStatusPlugin.class), pc.getPluginInstance(TestPlugin.class));
@@ -84,17 +84,17 @@ public class PluginCollectionTest {
     public void canLoadPlayPluginsFromASingleDescriptor() {
         Play.configuration.setProperty("play.plugins.descriptor", "play/plugins/custom-play.plugins");
         PluginCollection pc = new PluginCollection();
-        assertThat(pc.loadPlayPluginDescriptors().size()).isEqualTo(1);
-        assertThat(pc.loadPlayPluginDescriptors().get(0).toString()).endsWith("play/plugins/custom-play.plugins");
+        assertThat(pc.getPlayPluginFileUrls().size()).isEqualTo(1);
+        assertThat(pc.getPlayPluginFileUrls().get(0).toString()).endsWith("play/plugins/custom-play.plugins");
     }
 
     @Test
     public void canLoadPlayPluginsFromMultipleDescriptors() {
         Play.configuration.setProperty("play.plugins.descriptor", "play/plugins/custom-play.plugins,play.plugins.sample");
         PluginCollection pc = new PluginCollection();
-        assertThat(pc.loadPlayPluginDescriptors().size()).isEqualTo(2);
-        assertThat(pc.loadPlayPluginDescriptors().get(0).toString()).endsWith("play/plugins/custom-play.plugins");
-        assertThat(pc.loadPlayPluginDescriptors().get(1).toString()).endsWith("play.plugins.sample");
+        assertThat(pc.getPlayPluginFileUrls().size()).isEqualTo(2);
+        assertThat(pc.getPlayPluginFileUrls().get(0).toString()).endsWith("play/plugins/custom-play.plugins");
+        assertThat(pc.getPlayPluginFileUrls().get(1).toString()).endsWith("play.plugins.sample");
     }
 
     @Test


### PR DESCRIPTION
Allow a minimal way to init RePlay:

* no modules (we dont use them)
* no routes from routes file: we use the `resetForTest()` method nowadays to set our test defs based on a Kotlin file
* no plugins from `.plugins` file: we want to set them from code
* no loading of config file `config/application.conf` (we stopped using it and use configure our app from code)

Additional changes:

* rename  `resetForTest()` to `setRoutes(...)`  as we use it to load our in-Kotlin-code route definitions (and the tests do not seem to use it at all)
* rename `setRoutes()` to `loadRoutesFromFile()` to articulate the difference with `setRoutes(...)` (which it calls)
* re-use the renamed `setRoutes(...)` method by the `loadRoutesFromFile()` (no parameters) method to better signal intent
* rename internal `loadPlayPluginDescriptors()` to `getPlayPluginFileUrls()` as the name PluginDescriptors was used both for the `.plugin` files and for a class named... `PluginDescriptors`. i refer to the files as `PlayPluginFile` now both in code and docs to remove the ambiguity.
* split out the `init()` method over some private methods that are reused by both init() and minimalInit()