### PR TITLE
Expose plugin descriptor

### DIFF
--- a/framework/src/play/plugins/PluginCollection.java
+++ b/framework/src/play/plugins/PluginCollection.java
@@ -49,6 +49,12 @@ public class PluginCollection {
      */
     private final List<PlayPlugin> allPlugins = new ArrayList<>();
 
+    public PluginCollection() {}
+
+    public PluginCollection(SortedSet<PluginDescriptor> pluginsToLoad) {
+        loadPlugins(pluginsToLoad);
+    }
+
     /**
      * Load plugins from .plugin files, if any
      */

--- a/framework/src/play/plugins/PluginDescriptor.java
+++ b/framework/src/play/plugins/PluginDescriptor.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 
 import static java.util.Objects.hash;
 
-class PluginDescriptor implements Comparable<PluginDescriptor> {
+public class PluginDescriptor implements Comparable<PluginDescriptor> {
   public final String name;
   public final int index;
   public final URL url;


### PR DESCRIPTION
Missed that the PluginDescriptor should be part of the erxposed API.