### PR TITLE
fix serving static resources

### DIFF
--- a/framework/src/play/server/netty3/FileService.java
+++ b/framework/src/play/server/netty3/FileService.java
@@ -23,120 +23,138 @@ import java.util.concurrent.TimeUnit;
 import static java.lang.System.nanoTime;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCEPT_RANGES;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
-public class FileService  {
-    private static final Logger logger = LoggerFactory.getLogger(FileService.class);
+public class FileService {
+  private static final Logger logger = LoggerFactory.getLogger(FileService.class);
 
-    public void serve(File localFile, HttpRequest nettyRequest, HttpResponse nettyResponse, ChannelHandlerContext ctx, Request request, Response response, Channel channel) throws FileNotFoundException {
-        long startedAt = nanoTime();
-        String file = localFile.getAbsolutePath();
-        RandomAccessFile raf = new RandomAccessFile(localFile, "r");
+  public void serve(File localFile, HttpRequest nettyRequest, HttpResponse nettyResponse, ChannelHandlerContext ctx, 
+                    Request request, Response response, Channel channel) throws FileNotFoundException {
+    long startedAt = nanoTime();
+    String file = localFile.getAbsolutePath();
+    RandomAccessFile raf = new RandomAccessFile(localFile, "r");
 
-        try {
-            long fileLength = raf.length();
-            boolean isKeepAlive = HttpHeaders.isKeepAlive(nettyRequest) && nettyRequest.getProtocolVersion().equals(HttpVersion.HTTP_1_1);
-            String fileContentType = MimeTypes.getContentType(localFile.getName(), "text/plain");
-            String contentType = response.contentType != null ? response.contentType : fileContentType;
+    try {
+      long fileLength = raf.length();
+      boolean isKeepAlive = HttpHeaders.isKeepAlive(nettyRequest) && nettyRequest.getProtocolVersion().equals(HTTP_1_1);
+      String fileContentType = MimeTypes.getContentType(localFile.getName(), "text/plain");
+      String contentType = response.contentType != null ? response.contentType : fileContentType;
 
-            if (logger.isTraceEnabled()) {
-                logger.trace("serving {}, keepAlive:{}, contentType:{}, fileLength:{}, request.path:{}", file,
-                  isKeepAlive, contentType, fileLength, request.path);
-            }
+      if (logger.isTraceEnabled()) {
+        logger.trace("serving {}, keepAlive:{}, contentType:{}, fileLength:{}, request.path:{}", file,
+          isKeepAlive, contentType, fileLength, request.path);
+      }
 
-            setHeaders(nettyResponse, fileLength, contentType);
-            writeFileContent(file, nettyRequest, nettyResponse, channel, raf, isKeepAlive, fileContentType, startedAt);
+      setHeaders(nettyResponse, fileLength, contentType);
+      writeFileContent(file, nettyRequest, nettyResponse, channel, raf, isKeepAlive, fileContentType, startedAt);
 
-        } catch (Throwable e) {
-            logger.error("Failed to serve {} in {} ms", file, formatNanos(nanoTime() - startedAt), e);
-            closeSafely(localFile, raf, request.path);
-            closeSafely(ctx, request.path);
-        }
+    }
+    catch (Throwable e) {
+      logger.error("Failed to serve {} in {} ms", file, formatNanos(nanoTime() - startedAt), e);
+      closeSafely(localFile, raf, request.path);
+      closeSafely(ctx, request.path);
+    }
+  }
+
+  private void closeSafely(File localFile, Closeable closeable, String path) {
+    try {
+      if (closeable != null) {
+        closeable.close();
+      }
+    }
+    catch (IOException e) {
+      logger.warn("Failed to close {}, request.path:{}", localFile.getAbsolutePath(), path, e);
+    }
+  }
+
+  private void closeSafely(ChannelHandlerContext ctx, String path) {
+    try {
+      if (ctx.getChannel().isOpen()) {
+        ctx.getChannel().close();
+      }
+    }
+    catch (Throwable ex) {
+      logger.warn("Failed to closed channel, request.path:{}", path, ex);
+    }
+  }
+
+  private void writeFileContent(String file, HttpRequest nettyRequest, HttpResponse nettyResponse, Channel channel,
+                                RandomAccessFile raf, boolean isKeepAlive, String fileContentType,
+                                long startedAt) throws IOException {
+    ChannelFuture writeFuture = null;
+
+    if (!nettyRequest.getMethod().equals(HttpMethod.HEAD)) {
+      ChunkedInput chunkedInput = getChunkedInput(file, raf, fileContentType, nettyRequest, nettyResponse);
+      if (channel.isOpen()) {
+        channel.write(nettyResponse);
+        writeFuture = channel.write(chunkedInput);
+      }
+      else {
+        logger.debug("Try to write {} on a closed channel[keepAlive:{}]: Remote host may have closed the connection", file, isKeepAlive);
+      }
+    }
+    else {
+      if (channel.isOpen()) {
+        writeFuture = channel.write(nettyResponse);
+      }
+      else {
+        logger.debug("Try to write {} on a closed channel[keepAlive:{}]: Remote host may have closed the connection", file, isKeepAlive);
+      }
+      raf.close();
+      logger.trace("served {} in {} ms", file, formatNanos(nanoTime() - startedAt));
     }
 
-    private void closeSafely(File localFile, Closeable closeable, String path) {
-        try {
-            if (closeable != null) {
-                closeable.close();
-            }
-        }
-        catch (IOException e) {
-            logger.warn("Failed to close {}, request.path:{}", localFile.getAbsolutePath(), path, e);
-        }
+    if (writeFuture != null) {
+      writeFuture.addListener(new FileServingListener(file, startedAt));
+      if (!isKeepAlive) {
+        writeFuture.addListener(ChannelFutureListener.CLOSE);
+      }
+    }
+  }
+
+  private void setHeaders(HttpResponse nettyResponse, long fileLength, String contentType) {
+    if (!nettyResponse.getStatus().equals(HttpResponseStatus.NOT_MODIFIED)) {
+      // Add 'Content-Length' header only for a keep-alive connection.
+      nettyResponse.headers().set(HttpHeaders.Names.CONTENT_LENGTH, String.valueOf(fileLength));
     }
 
-    private void closeSafely(ChannelHandlerContext ctx, String path) {
-        try {
-            if (ctx.getChannel().isOpen()) {
-                ctx.getChannel().close();
-            }
-        }
-        catch (Throwable ex) {
-            logger.warn("Failed to closed channel, request.path:{}", path, ex);
-        }
+    nettyResponse.headers().set(CONTENT_TYPE, contentType);
+    nettyResponse.headers().set(ACCEPT_RANGES, HttpHeaders.Values.BYTES);
+  }
+
+  private ChunkedInput getChunkedInput(String file, RandomAccessFile raf, String contentType, 
+                                       HttpRequest nettyRequest, HttpResponse nettyResponse) throws IOException {
+    if (ByteRangeInput.accepts(nettyRequest)) {
+      ByteRangeInput server = new ByteRangeInput(file, raf, contentType, nettyRequest);
+      server.prepareNettyResponse(nettyResponse);
+      return server;
+    }
+    else {
+      return new ChunkedFile(raf);
+    }
+  }
+
+  private static String formatNanos(long executionTimeNanos) {
+    return String.format("%d.%d", TimeUnit.NANOSECONDS.toMillis(executionTimeNanos), executionTimeNanos % 1_000_000 / 1_000);
+  }
+
+  private static class FileServingListener implements ChannelFutureListener {
+    private final String file;
+    private final long startedAt;
+
+    public FileServingListener(String file, long startedAt) {
+      this.file = file;
+      this.startedAt = startedAt;
     }
 
-    private void writeFileContent(String file, HttpRequest nettyRequest, HttpResponse nettyResponse, Channel channel,
-                                  RandomAccessFile raf, boolean isKeepAlive, String fileContentType,
-                                  long startedAt) throws IOException {
-        ChannelFuture writeFuture = null;
-
-        if (!nettyRequest.getMethod().equals(HttpMethod.HEAD)) {
-            ChunkedInput chunkedInput = getChunkedInput(file, raf, fileContentType, nettyRequest, nettyResponse);
-            if (channel.isOpen()) {
-                channel.write(nettyResponse);
-                writeFuture = channel.write(chunkedInput);
-            }
-            else {
-                logger.debug("Try to write {} on a closed channel[keepAlive:{}]: Remote host may have closed the connection", file, isKeepAlive);
-            }
-        }
-        else {
-            if (channel.isOpen()) {
-                writeFuture = channel.write(nettyResponse);
-            }
-            else {
-                logger.debug("Try to write {} on a closed channel[keepAlive:{}]: Remote host may have closed the connection", file, isKeepAlive);
-            }
-            raf.close();
-            logger.trace("served {} in {} ms", file, formatNanos(nanoTime() - startedAt));
-        }
-
-        if (writeFuture != null) {
-            writeFuture.addListener(future -> {
-                if (future.isSuccess()) {
-                    logger.trace("served {} in {} ms", file, formatNanos(nanoTime() - startedAt));
-                }
-                else {
-                    logger.trace("failed to serve {} in {} ms", file, formatNanos(nanoTime() - startedAt), future.getCause());
-                }
-            });
-            if (!isKeepAlive) {
-                writeFuture.addListener(ChannelFutureListener.CLOSE);
-            }
-        }
+    @Override
+    public void operationComplete(ChannelFuture future) {
+      if (future.isSuccess()) {
+        logger.trace("served {} in {} ms", file, formatNanos(nanoTime() - startedAt));
+      }
+      else {
+        logger.trace("failed to serve {} in {} ms", file, formatNanos(nanoTime() - startedAt), future.getCause());
+      }
     }
-
-    private void setHeaders(HttpResponse nettyResponse, long fileLength, String contentType) {
-        if (!nettyResponse.getStatus().equals(HttpResponseStatus.NOT_MODIFIED)) {
-            // Add 'Content-Length' header only for a keep-alive connection.
-            nettyResponse.headers().set(HttpHeaders.Names.CONTENT_LENGTH, String.valueOf(fileLength));
-        }
-
-        nettyResponse.headers().set(CONTENT_TYPE, contentType);
-        nettyResponse.headers().set(ACCEPT_RANGES, HttpHeaders.Values.BYTES);
-    }
-
-    private ChunkedInput getChunkedInput(String file, RandomAccessFile raf, String contentType, HttpRequest nettyRequest, HttpResponse nettyResponse) throws IOException {
-        if (ByteRangeInput.accepts(nettyRequest)) {
-            ByteRangeInput server = new ByteRangeInput(file, raf, contentType, nettyRequest);
-            server.prepareNettyResponse(nettyResponse);
-            return server;
-        } else {
-            return new ChunkedFile(raf);
-        }
-    }
-
-    private String formatNanos(long executionTimeNanos) {
-        return String.format("%d.%d", TimeUnit.NANOSECONDS.toMillis(executionTimeNanos), executionTimeNanos % 1_000_000 / 1_000);
-    }
+  }
 }

--- a/framework/src/play/server/netty3/FileService.java
+++ b/framework/src/play/server/netty3/FileService.java
@@ -102,7 +102,14 @@ public class FileService  {
         }
 
         if (writeFuture != null) {
-            writeFuture.addListener(future -> logger.trace("served {} in {} ms", file, formatNanos(nanoTime() - startedAt)));
+            writeFuture.addListener(future -> {
+                if (future.isSuccess()) {
+                    logger.trace("served {} in {} ms", file, formatNanos(nanoTime() - startedAt));
+                }
+                else {
+                    logger.trace("failed to serve {} in {} ms", file, formatNanos(nanoTime() - startedAt), future.getCause());
+                }
+            });
             if (!isKeepAlive) {
                 writeFuture.addListener(ChannelFutureListener.CLOSE);
             }

--- a/framework/src/play/server/netty4/FileService.java
+++ b/framework/src/play/server/netty4/FileService.java
@@ -2,8 +2,19 @@ package play.server.netty4;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.*;
-import io.netty.handler.codec.http.*;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelProgressiveFuture;
+import io.netty.channel.ChannelProgressiveFutureListener;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.stream.ChunkedFile;
 import io.netty.handler.stream.ChunkedInput;
 import org.slf4j.Logger;
@@ -12,140 +23,158 @@ import play.libs.MimeTypes;
 import play.mvc.Http.Request;
 import play.mvc.Http.Response;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.util.concurrent.TimeUnit;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT_RANGES;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static java.lang.System.nanoTime;
-import static io.netty.handler.codec.http.HttpHeaders.Names.ACCEPT_RANGES;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
 
-public class FileService  {
-    private static final Logger logger = LoggerFactory.getLogger(FileService.class);
+public class FileService {
+  private static final Logger logger = LoggerFactory.getLogger(FileService.class);
 
-    public void serve(File localFile, HttpRequest nettyRequest, HttpResponse nettyResponse, ChannelHandlerContext ctx, Request request, Response response, Channel channel) throws FileNotFoundException {
-        logger.trace("FileService.serve: begin");
-        long startedAt = nanoTime();
-        String filePath = localFile.getAbsolutePath();
-        RandomAccessFile raf = new RandomAccessFile(localFile, "r");
+  public void serve(File localFile, HttpRequest nettyRequest, HttpResponse nettyResponse, ChannelHandlerContext ctx, 
+                    Request request, Response response, Channel channel) throws FileNotFoundException {
+    logger.trace("FileService.serve: begin");
+    long startedAt = nanoTime();
+    String filePath = localFile.getAbsolutePath();
+    RandomAccessFile raf = new RandomAccessFile(localFile, "r");
 
-        try {
-            long fileLength = raf.length();
-            boolean isKeepAlive = HttpUtil.isKeepAlive(nettyRequest) && nettyRequest.protocolVersion().equals(HttpVersion.HTTP_1_1);
-            String fileContentType = MimeTypes.getContentType(localFile.getName(), "text/plain");
-            String contentType = response.contentType != null ? response.contentType : fileContentType;
+    try {
+      long fileLength = raf.length();
+      boolean isKeepAlive = HttpUtil.isKeepAlive(nettyRequest) && nettyRequest.protocolVersion().equals(HTTP_1_1);
+      String fileContentType = MimeTypes.getContentType(localFile.getName(), "text/plain");
+      String contentType = response.contentType != null ? response.contentType : fileContentType;
 
-            if (logger.isTraceEnabled()) {
-                logger.trace("serving {}, keepAlive:{}, contentType:{}, fileLength:{}, request.path:{}", filePath,
-                  isKeepAlive, contentType, fileLength, request.path);
-            }
+      if (logger.isTraceEnabled()) {
+        logger.trace("serving {}, keepAlive:{}, contentType:{}, fileLength:{}, request.path:{}", filePath,
+          isKeepAlive, contentType, fileLength, request.path);
+      }
 
-            setHeaders(nettyResponse, fileLength, contentType);
-            writeFileContent(filePath, nettyRequest, nettyResponse, channel, raf, isKeepAlive, fileContentType, startedAt);
-            logger.trace("FileService.serve: end");
-        } catch (Throwable e) {
-            logger.error("Failed to serve {} in {} ms", filePath, formatNanos(nanoTime() - startedAt), e);
-            closeSafely(localFile, raf, request.path);
-            closeSafely(ctx, request.path);
-        }
+      setHeaders(nettyResponse, fileLength, contentType);
+      writeFileContent(filePath, nettyRequest, nettyResponse, channel, raf, isKeepAlive, fileContentType, startedAt);
+      logger.trace("FileService.serve: end");
+    }
+    catch (Throwable e) {
+      logger.error("Failed to serve {} in {} ms", filePath, formatNanos(nanoTime() - startedAt), e);
+      closeSafely(localFile, raf, request.path);
+      closeSafely(ctx, request.path);
+    }
+  }
+
+  private void closeSafely(File localFile, Closeable closeable, String path) {
+    try {
+      if (closeable != null) {
+        closeable.close();
+      }
+    }
+    catch (IOException e) {
+      logger.warn("Failed to close {}, request.path:{}", localFile.getAbsolutePath(), path, e);
+    }
+  }
+
+  private void closeSafely(ChannelHandlerContext ctx, String path) {
+    try {
+      if (ctx.channel().isOpen()) {
+        ctx.channel().close();
+      }
+    }
+    catch (Throwable ex) {
+      logger.warn("Failed to closed channel, request.path:{}", path, ex);
+    }
+  }
+
+  private void writeFileContent(String filePath, HttpRequest nettyRequest, HttpResponse nettyResponse, Channel channel,
+                                RandomAccessFile raf, boolean isKeepAlive, String fileContentType,
+                                long startedAt) throws IOException {
+    ChannelFuture sendFileFuture = null;
+    ChannelFuture lastContentFuture = null;
+
+    if (!nettyRequest.method().equals(HttpMethod.HEAD)) {
+      ChunkedInput<ByteBuf> chunkedInput = getChunkedInput(filePath, raf, fileContentType, nettyRequest, nettyResponse);
+      if (channel.isOpen()) {
+        channel.write(nettyResponse);
+        sendFileFuture = channel.write(chunkedInput, channel.newProgressivePromise());
+        lastContentFuture = channel.writeAndFlush(Unpooled.EMPTY_BUFFER);
+      }
+      else {
+        logger.debug("Try to write {} on a closed channel[keepAlive:{}]: Remote host may have closed the connection", filePath, isKeepAlive);
+      }
+    }
+    else {
+      if (channel.isOpen()) {
+        lastContentFuture = channel.writeAndFlush(nettyResponse);
+      }
+      else {
+        logger.debug("Try to write {} on a closed channel[keepAlive:{}]: Remote host may have closed the connection", filePath, isKeepAlive);
+      }
+      raf.close();
+      logger.trace("HEAD served {} in {} ms", filePath, formatNanos(nanoTime() - startedAt));
     }
 
-    private void closeSafely(File localFile, Closeable closeable, String path) {
-        try {
-            if (closeable != null) {
-                closeable.close();
-            }
-        }
-        catch (IOException e) {
-            logger.warn("Failed to close {}, request.path:{}", localFile.getAbsolutePath(), path, e);
-        }
+    if (sendFileFuture != null) {
+      sendFileFuture.addListener(new FileServingListener(filePath, startedAt));
+      if (!isKeepAlive) {
+        lastContentFuture.addListener(ChannelFutureListener.CLOSE);
+      }
+    }
+  }
+
+  private void setHeaders(HttpResponse nettyResponse, long fileLength, String contentType) {
+    if (!nettyResponse.status().equals(HttpResponseStatus.NOT_MODIFIED)) {
+      // Add 'Content-Length' header only for a keep-alive connection.
+      nettyResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(fileLength));
     }
 
-    private void closeSafely(ChannelHandlerContext ctx, String path) {
-        try {
-            if (ctx.channel().isOpen()) {
-                ctx.channel().close();
-            }
-        }
-        catch (Throwable ex) {
-            logger.warn("Failed to closed channel, request.path:{}", path, ex);
-        }
+    nettyResponse.headers().set(CONTENT_TYPE, contentType);
+    nettyResponse.headers().set(ACCEPT_RANGES, HttpHeaderValues.BYTES);
+  }
+
+  private ChunkedInput<ByteBuf> getChunkedInput(String filePath, RandomAccessFile raf, String contentType, 
+                                                HttpRequest nettyRequest, HttpResponse nettyResponse) throws IOException {
+    if (ByteRangeInput.accepts(nettyRequest)) {
+      logger.trace("getChunkedInput: serving range");
+      ByteRangeInput server = new ByteRangeInput(filePath, raf, contentType, nettyRequest);
+      server.prepareNettyResponse(nettyResponse);
+      return server;
+    }
+    else {
+      logger.trace("getChunkedInput: serving chunkedfile");
+      return new ChunkedFile(raf);
+    }
+  }
+
+  private static String formatNanos(long executionTimeNanos) {
+    return String.format("%d.%d", TimeUnit.NANOSECONDS.toMillis(executionTimeNanos), executionTimeNanos % 1_000_000 / 1_000);
+  }
+
+  private static class FileServingListener implements ChannelProgressiveFutureListener {
+    private final String filePath;
+    private final long startedAt;
+
+    public FileServingListener(String filePath, long startedAt) {
+      this.filePath = filePath;
+      this.startedAt = startedAt;
     }
 
-    private void writeFileContent(String filePath, HttpRequest nettyRequest, HttpResponse nettyResponse, Channel channel,
-                                  RandomAccessFile raf, boolean isKeepAlive, String fileContentType,
-                                  long startedAt) throws IOException {
-        ChannelFuture sendFileFuture = null;
-        ChannelFuture lastContentFuture = null;
-
-        if (!nettyRequest.method().equals(HttpMethod.HEAD)) {
-            ChunkedInput<ByteBuf> chunkedInput = getChunkedInput(filePath, raf, fileContentType, nettyRequest, nettyResponse);
-            if (channel.isOpen()) {
-                channel.write(nettyResponse);
-                sendFileFuture = channel.write(chunkedInput, channel.newProgressivePromise());
-                lastContentFuture = channel.writeAndFlush(Unpooled.EMPTY_BUFFER);
-            }
-            else {
-                logger.debug("Try to write {} on a closed channel[keepAlive:{}]: Remote host may have closed the connection", filePath, isKeepAlive);
-            }
-        }
-        else {
-            if (channel.isOpen()) {
-                lastContentFuture = channel.writeAndFlush(nettyResponse);
-            }
-            else {
-                logger.debug("Try to write {} on a closed channel[keepAlive:{}]: Remote host may have closed the connection", filePath, isKeepAlive);
-            }
-            raf.close();
-            logger.trace("HEAD served {} in {} ms", filePath, formatNanos(nanoTime() - startedAt));
-        }
-
-        if (sendFileFuture != null) {
-            sendFileFuture.addListener(new ChannelProgressiveFutureListener() {
-                                           @Override
-                                           public void operationProgressed(ChannelProgressiveFuture future, long progress, long total) {
-                                               logger.trace("{} Transfer progress: {}/{} (success: {})", future.channel(), progress, total < 0 ? "?" : total,  future.isSuccess());
-                                           }
-
-                                           @Override
-                                           public void operationComplete(ChannelProgressiveFuture future) {
-                                               if (future.isSuccess()) {
-                                                   logger.trace("served {} in {} ms", filePath, formatNanos(nanoTime() - startedAt));
-                                               }
-                                               else {
-                                                   logger.error("failed to serve {} in {} ms", filePath, formatNanos(nanoTime() - startedAt), future.cause());
-                                               }
-                                           }
-                                       }
-            );
-            if (!isKeepAlive) {
-                lastContentFuture.addListener(ChannelFutureListener.CLOSE);
-            }
-        }
+    @Override
+    public void operationProgressed(ChannelProgressiveFuture future, long progress, long total) {
+      logger.trace("{} Transfer progress: {}/{} (success: {})", future.channel(), progress, total < 0 ? "?" : total, future.isSuccess());
     }
 
-    private void setHeaders(HttpResponse nettyResponse, long fileLength, String contentType) {
-        if (!nettyResponse.status().equals(HttpResponseStatus.NOT_MODIFIED)) {
-            // Add 'Content-Length' header only for a keep-alive connection.
-            nettyResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(fileLength));
-        }
-
-        nettyResponse.headers().set(CONTENT_TYPE, contentType);
-        nettyResponse.headers().set(ACCEPT_RANGES, HttpHeaderValues.BYTES);
+    @Override
+    public void operationComplete(ChannelProgressiveFuture future) {
+      if (future.isSuccess()) {
+        logger.trace("served {} in {} ms", filePath, formatNanos(nanoTime() - startedAt));
+      }
+      else {
+        logger.error("failed to serve {} in {} ms", filePath, formatNanos(nanoTime() - startedAt), future.cause());
+      }
     }
-
-    private ChunkedInput<ByteBuf> getChunkedInput(String filePath, RandomAccessFile raf, String contentType, HttpRequest nettyRequest, HttpResponse nettyResponse) throws IOException {
-        if (ByteRangeInput.accepts(nettyRequest)) {
-            logger.trace("getChunkedInput: serving range");
-            ByteRangeInput server = new ByteRangeInput(filePath, raf, contentType, nettyRequest);
-            server.prepareNettyResponse(nettyResponse);
-            return server;
-        } else {
-            logger.trace("getChunkedInput: serving chunkedfile");
-            return new ChunkedFile(raf);
-        }
-    }
-
-    private String formatNanos(long executionTimeNanos) {
-        return String.format("%d.%d", TimeUnit.NANOSECONDS.toMillis(executionTimeNanos), executionTimeNanos % 1_000_000 / 1_000);
-    }
+  }
 }

--- a/framework/src/play/server/netty4/FileService.java
+++ b/framework/src/play/server/netty4/FileService.java
@@ -101,20 +101,21 @@ public class FileService  {
 
         if (sendFileFuture != null) {
             sendFileFuture.addListener(new ChannelProgressiveFutureListener() {
-                                        @Override
-                                        public void operationProgressed(ChannelProgressiveFuture future, long progress, long total) throws Exception {
-                                            if (total < 0) { // total unknown
-                                                logger.trace(future.channel() + " Transfer progress: " + progress);
-                                            } else {
-                                                logger.trace(future.channel() + " Transfer progress: " + progress + " / " + total);
-                                            }
-                                        }
+                                           @Override
+                                           public void operationProgressed(ChannelProgressiveFuture future, long progress, long total) {
+                                               logger.trace("{} Transfer progress: {}/{} (success: {})", future.channel(), progress, total < 0 ? "?" : total,  future.isSuccess());
+                                           }
 
-                                        @Override
-                                        public void operationComplete(ChannelProgressiveFuture future) throws Exception {
-                                            logger.trace("served {} in {} ms", filePath, formatNanos(nanoTime() - startedAt));
-                                        }
-                                    }
+                                           @Override
+                                           public void operationComplete(ChannelProgressiveFuture future) {
+                                               if (future.isSuccess()) {
+                                                   logger.trace("served {} in {} ms", filePath, formatNanos(nanoTime() - startedAt));
+                                               }
+                                               else {
+                                                   logger.error("failed to serve {} in {} ms", filePath, formatNanos(nanoTime() - startedAt), future.cause());
+                                               }
+                                           }
+                                       }
             );
             if (!isKeepAlive) {
                 lastContentFuture.addListener(ChannelFutureListener.CLOSE);


### PR DESCRIPTION
Until this change, we ignored the fact that Future might be failed, and just logged "serving succeeded" message.

Thus we didn't see this error after upgrade to Netty4:

```
ERROR ~ failed to serve /Users/andrei/projects/replay/replay-tests/helloworld/app/public/hello_world.txt in 6.154 ms
io.netty.handler.codec.EncoderException: java.lang.IllegalStateException: unexpected message type: PooledUnsafeHeapByteBuf, state: 0
	at io.netty.handler.codec.http.HttpObjectEncoder.write(HttpObjectEncoder.java:108)
	at io.netty.channel.CombinedChannelDuplexHandler.write(CombinedChannelDuplexHandler.java:346)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:879)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:940)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:966)
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:934)
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:984)
	at io.netty.handler.stream.ChunkedWriteHandler.doFlush(ChunkedWriteHandler.java:269)
	at io.netty.handler.stream.ChunkedWriteHandler.flush(ChunkedWriteHandler.java:131)
	at io.netty.channel.AbstractChannelHandlerContext.invokeFlush0(AbstractChannelHandlerContext.java:923)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:941)

Caused by: java.lang.IllegalStateException: unexpected message type: PooledUnsafeHeapByteBuf, state: 0
	at io.netty.handler.codec.http.HttpObjectEncoder.throwUnexpectedMessageTypeEx(HttpObjectEncoder.java:348)
	at io.netty.handler.codec.http.HttpObjectEncoder.encodeNotHttpMessageContentTypes(HttpObjectEncoder.java:267)
	at io.netty.handler.codec.http.HttpObjectEncoder.encode(HttpObjectEncoder.java:181)
	at io.netty.handler.codec.http.HttpObjectEncoder.write(HttpObjectEncoder.java:97)
```