### PR TITLE
make UI tests params configurable in "criminals" app too (see #67)

### DIFF
--- a/replay-tests/criminals/test/ui/BaseUITest.java
+++ b/replay-tests/criminals/test/ui/BaseUITest.java
@@ -26,7 +26,6 @@ public class BaseUITest {
 
       Configuration.baseUrl = "http://127.0.0.1:" + port;
       Configuration.browserSize = "1024x800";
-      Configuration.browser = "chrome";
       Configuration.textCheck = FULL_TEXT;
 
       log.info("Started AUT at {}", Configuration.baseUrl);


### PR DESCRIPTION
Commit 858f2da5ba27 removed the hardwired dependency to Chrome browser (#67).

Later the "criminals" app was imported to help integration tests, reintroducing the hardwired dependency.

Fixes: 2bf34606a1c5