### PR TITLE
bump Guice from 5.1.0 to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1 (in progress)
+* bump Guice from 5.1.0 to 6.0.0 - see https://github.com/google/guice/wiki/Guice600 
+
 ## 2.0.0 (released 18.04.2023) - see https://github.com/codeborne/replay/milestone/10?closed=1
 * added experimental support for Netty4 (Netty 3 is also still used by default)  --  thanks to Szabolcs Hubai! (#25) (#95)
 * added backend `javanet` as an alternative for Netty3/Netty4 (#152)

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   api('commons-logging:commons-logging:1.2')
   api('javax.mail:mail:1.4.7')
   api('javax.inject:javax.inject:1')
+  api('jakarta.inject:jakarta.inject-api:2.0.1')
   implementation('ch.qos.reload4j:reload4j:1.2.25')
   implementation('org.ehcache:ehcache:3.10.8')
   api('net.sf.oval:oval:3.2.1')

--- a/guice/build.gradle
+++ b/guice/build.gradle
@@ -2,8 +2,7 @@ dependencies {
   api project(':framework')
   testImplementation project(':framework').sourceSets.test.compileClasspath
 
-  api('com.google.inject:guice:5.1.0')
-  implementation('aopalliance:aopalliance:1.0') {transitive = false}
+  api('com.google.inject:guice:6.0.0')
 }
 
 apply from: rootProject.file('gradle/deploy.gradle')


### PR DESCRIPTION
This allows to start migration from javax to jakarta namespace.

see https://github.com/google/guice/wiki/Guice600