### PR TITLE
Typo was made around netty3 dependency in play.server.Server.start()

### DIFF
--- a/framework/src/play/server/Server.java
+++ b/framework/src/play/server/Server.java
@@ -15,7 +15,7 @@ public class Server {
 
   public int start() {
     throw new IllegalStateException(
-      "Please add the dependency com.codeborne.replay:javanet:netty3, com.codeborne.replay:netty4 or "
+      "Please add the dependency com.codeborne.replay:netty3, com.codeborne.replay:netty4 or "
       + "com.codeborne.replay:javanet to your project, and make sure it is declared before "
       + "com.codeborne.replay:framework");
   }


### PR DESCRIPTION
It is no "javanet:" between "replay:" and "netty3": `com.codeborne.replay:netty3`

Fixes: 02596f83a98 ("Make the error message more actionable")