### PR TITLE
Load `conf/log4j.properties` automatically if exists

### DIFF
--- a/framework/src/play/PlayLoggingSetup.java
+++ b/framework/src/play/PlayLoggingSetup.java
@@ -12,7 +12,13 @@ public class PlayLoggingSetup {
     String log4jPath = Play.configuration.getProperty("application.log.path", "/log4j.xml");
     URL log4jConf = PlayLoggingSetup.class.getResource(log4jPath);
     if (log4jConf == null) {
-      log4jPath = Play.configuration.getProperty("application.log.path", "/log4j.properties");
+      // try log4j.properties from the "conf/" directory/classpath
+      log4jPath = "/conf/log4j.properties";
+      log4jConf = PlayLoggingSetup.class.getResource(log4jPath);
+    }
+    if (log4jConf == null) {
+      // falling back to "/log4j.properties"
+      log4jPath = "/log4j.properties";
       log4jConf = PlayLoggingSetup.class.getResource(log4jPath);
     }
     if (log4jConf == null) {

--- a/framework/test/conf/log4j.properties
+++ b/framework/test/conf/log4j.properties
@@ -1,0 +1,9 @@
+log4j.rootLogger=DEBUG, PropertiesConsoleAppender
+
+log4j.appender.PropertiesConsoleAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.PropertiesConsoleAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.PropertiesConsoleAppender.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c: %m%n
+
+
+
+log4j.logger.logtest.confdir=ERROR

--- a/framework/test/play/PlayLoggingSetupTest.java
+++ b/framework/test/play/PlayLoggingSetupTest.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import play.libs.Files;
 
 import java.io.File;
+import java.net.URISyntaxException;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,5 +58,22 @@ public class PlayLoggingSetupTest {
     loggingSetup.init();
     Logger log4jLogger = Logger.getLogger("logtest.xml");
     assertThat(log4jLogger.getLevel()).isEqualTo(Level.ERROR);
+  }
+
+  @Test
+  public void init_with_conf_dir() {
+    loggingSetup.init();
+    Logger log4jLogger = Logger.getLogger("logtest.confdir");
+    assertThat(log4jLogger.getLevel()).isEqualTo(Level.ERROR);
+    assertThat(Logger.getRootLogger().getLevel()).isEqualTo(Level.DEBUG);
+  }
+
+  @Test
+  public void init_with_default_config() {
+    // delete the conf/log4j.properties from test classpath and fallback to the framework log4j.properties
+    File confProp = new File(getClass().getResource("/conf/log4j.properties").getFile());
+    assertThat(confProp.delete()).isTrue();
+    loggingSetup.init();
+    assertThat(Logger.getRootLogger().getLevel()).isEqualTo(Level.INFO);
   }
 }


### PR DESCRIPTION
Hi @asolntsev ,

this is another low hanging fruit: let the Framework load the `log4j.properties` from `conf` directory if exists.
I also added a failing test before implementing the improvement.