### PR TITLE
Drop a hint on why there is no BeanWrapper

### DIFF
--- a/framework/src/play/data/binding/Binder.java
+++ b/framework/src/play/data/binding/Binder.java
@@ -323,7 +323,7 @@ public abstract class Binder {
 
         BeanWrapper bw = getBeanWrapper(bean.getClass());
         if (bw == null) {
-            throw new RuntimeException(String.format("No BeanWrapper for '%s'", bean.getClass().getSimpleName()));
+            throw new RuntimeException(String.format("No BeanWrapper for '%s'", bean.getClass().getName()));
         }
         for (BeanWrapper.Property prop : bw.getWrappers()) {
             ParamNode propParamNode = paramNode.getChild(prop.getName());

--- a/framework/src/play/data/binding/Binder.java
+++ b/framework/src/play/data/binding/Binder.java
@@ -322,6 +322,9 @@ public abstract class Binder {
     private static void internalBindBean(Http.Request request, Session session, ParamNode paramNode, Object bean, BindingAnnotations bindingAnnotations) {
 
         BeanWrapper bw = getBeanWrapper(bean.getClass());
+        if (bw == null) {
+            throw new RuntimeException(String.format("No BeanWrapper for '%s'", bean.getClass().getSimpleName()));
+        }
         for (BeanWrapper.Property prop : bw.getWrappers()) {
             ParamNode propParamNode = paramNode.getChild(prop.getName());
             if (propParamNode != null) {


### PR DESCRIPTION
We got the following error:

```
by: java.lang.NullPointerException: Cannot invoke "play.data.binding.BeanWrapper.getWrappers()" because "bw" is null
at play.data.binding.Binder.internalBindBean(Binder.java:325)
at play.data.binding.Binder.bindBean(Binder.java:319)
at play.db.jpa.GenericModel.edit(GenericModel.java:206)
```

It seems that `BeanWrapper bw = getBeanWrapper(bean.getClass());` (Binder.java:324) can return null. I'm not sure why. Maybe because our bean (Entity) did not have a default constructor: that's my hunch for now.

Since it breaks down the line with a null BeanWrapper, I think it is better to fail early and provide some hint as to what class does not have a bean wrapper.