### PR TITLE
Make context provided controllers implementable

### DIFF
--- a/framework/src/play/mvc/Controller.java
+++ b/framework/src/play/mvc/Controller.java
@@ -5,7 +5,7 @@ import play.mvc.results.BadRequest;
 import play.mvc.results.Forbidden;
 import play.rebel.View;
 
-public class Controller implements PlayController {
+public class Controller implements PlayContextController {
   protected ActionContext actionContext;
   protected Http.Request request;
   protected Http.Response response;
@@ -15,7 +15,7 @@ public class Controller implements PlayController {
   protected Scope.RenderArgs renderArgs;
   protected Validation validation;
 
-  protected void setContext(ActionContext actionContext) {
+  public void setContext(ActionContext actionContext) {
     this.actionContext = actionContext;
     request = actionContext.request;
     response = actionContext.response;

--- a/framework/src/play/mvc/PlayContextController.java
+++ b/framework/src/play/mvc/PlayContextController.java
@@ -1,0 +1,12 @@
+package play.mvc;
+
+/**
+ * Interface for play controllers with ActionContext provided to them by the {@link play.mvc.ActionInvoker}.
+ * 
+ * This class your controllers should implement, when they need access to the {@link play.mvc.ActionContext}.
+ * In most cases, you can extend {@link play.mvc.Controller} which provides a basic set of features
+ * useful when implementing controllers.
+ */
+public interface PlayContextController extends PlayController {
+  void setContext(ActionContext actionContext);
+}

--- a/framework/src/play/mvc/PlayController.java
+++ b/framework/src/play/mvc/PlayController.java
@@ -3,8 +3,8 @@ package play.mvc;
 /**
  * Marker interface for play controllers
  * 
- * This is the class that your controllers should implement.
- * In most cases, you can extend play.mvc.Controller that contains all needed methods for controllers.
+ * This is the class that your controllers should implement when they need very few capabilities..
+ * In most cases, you can extend {@link play.mvc.Controller} which provides a basic set of features for controllers.
  */
 public interface PlayController {
 }


### PR DESCRIPTION
We currently inherit from `Controller`. I want to remove some of it's capabilities in some cases (say in case of controllers that are only concerned with API requests). And I want to add some capabilities in other cases.

So I added the PlayContextController interface in between Controller and PlayController which defines the setContext() method, so ActionInvoker will be able to add the context to the controller I implement.