### PR TITLE
Lower `persistence-api` version in line with Hibernate's requirement

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -28,8 +28,9 @@ dependencies {
   api("org.codehaus.groovy:groovy:$groovyVersion")
   api("org.codehaus.groovy:groovy-xml:$groovyVersion")
   api('org.hibernate:hibernate-core-jakarta:5.6.15.Final')
+  // Hibernate 5.6 series is only compatible with persistence-api:3.0.0
+  api('jakarta.persistence:jakarta.persistence-api:3.0.0')
   api('org.hibernate.common:hibernate-commons-annotations:6.0.6.Final')
-  api('jakarta.persistence:jakarta.persistence-api:3.1.0')
   implementation('org.hibernate:hibernate-ehcache:5.6.15.Final') {transitive = false}
   api("org.slf4j:slf4j-api:$slf4jVersion")
   api("org.slf4j:slf4j-reload4j:$slf4jVersion")


### PR DESCRIPTION
Found that hibernate 5.6 only supports persistence-api version 3.0.0

As explained here:

https://hibernate.org/orm/releases/