### PR TITLE
Remove deprecation from Injector.getBeanOfType

### DIFF
--- a/framework/src/play/inject/Injector.java
+++ b/framework/src/play/inject/Injector.java
@@ -8,9 +8,6 @@ public class Injector {
         Injector.beanSource = beanSource;
     }
 
-    /**
-     * @deprecated Use Play.beanSource instead
-     */
     @Deprecated
     public static <T> T getBeanOfType(String className) {
         try {
@@ -20,10 +17,6 @@ public class Injector {
         }
     }
 
-    /**
-     * @deprecated Use Play.beanSource instead
-     */
-    @Deprecated
     public static <T> T getBeanOfType(Class<T> clazz) {
         return beanSource.getBeanOfType(clazz);
     }


### PR DESCRIPTION
This is used internally and in our code and works better (actually works) than the replacement that is suggested.