### PR TITLE
Prevent ecj (used by fastergt plugin) updates for 3.34.0 and higher

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     - dependency-name: org.apache.poi:poi
     - dependency-name: org.apache.poi:poi-ooxml
     - dependency-name: org.apache.poi:poi-ooxml-schemas
+    - dependency-name: org.eclipse.jdt:ecj
+      versions:
+      - "[3.34.0,+]"
 
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/fastergt/build.gradle
+++ b/fastergt/build.gradle
@@ -1,6 +1,9 @@
 dependencies {
   implementation project(':framework')
-  implementation('org.eclipse.jdt:ecj:3.33.0') {transitive = false}
+  implementation('org.eclipse.jdt:ecj:3.33.0') {
+    transitive = false
+    because "ECJ 3.34.0 dropped Java 11 compatibility, see https://github.com/eclipse-jdt/eclipse.jdt.core/commit/c25e22b15eebcc780b1a6c54d7af1911841c49b8"
+  }
   implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
   implementation "org.apache.commons:commons-text:$commonsTextVersion"
   testImplementation project(':framework').sourceSets.test.compileClasspath


### PR DESCRIPTION
Replay still supports Java 11 but ECJ dropped that in version 3.34.0.
See https://github.com/eclipse-jdt/eclipse.jdt.core/commit/c25e22b15eebcc780b1a6c54d7af1911841c49b8

See previous dependabot attempts: #187, #247, #298