### PR TITLE
fix: avoid stale keep-alive sockets in UI tests

### DIFF
--- a/javanet/src/play/server/javanet/Server.java
+++ b/javanet/src/play/server/javanet/Server.java
@@ -40,6 +40,15 @@ public class Server {
   public int start() {
     System.setProperty("file.encoding", "utf-8");
 
+    // The JDK httpserver closes idle keep-alive connections after this interval (in SECONDS,
+    // default 30). Combined with HttpURLConnection's KeepAliveCache on the client this is racy:
+    // the cached socket can be silently closed by the server, then a later request reuses it
+    // and blocks in parseHTTPHeader until a read timeout fires. Push it well beyond any
+    // plausible inter-request gap, but allow callers to override.
+    if (System.getProperty("sun.net.httpserver.idleInterval") == null) {
+      System.setProperty("sun.net.httpserver.idleInterval", "600");
+    }
+
     String address = address();
     try {
       HttpServer server = HttpServer.create(new InetSocketAddress(address, port), 0);

--- a/replay-tests/criminals/test/ui/BaseUITest.java
+++ b/replay-tests/criminals/test/ui/BaseUITest.java
@@ -6,7 +6,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.commons.io.IOUtils.toByteArray;
 
 import com.codeborne.selenide.Configuration;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -15,9 +14,11 @@ import java.awt.Toolkit;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -33,6 +34,15 @@ import org.slf4j.LoggerFactory;
 import play.Play;
 
 public class BaseUITest {
+  static {
+    // Disable JVM-wide HttpURLConnection keep-alive cache. Otherwise, the warmup GET below
+    // can leave an idle TCP socket in KeepAliveCache that the JDK httpserver later closes
+    // (sun.net.httpserver.idleInterval, 30 s by default), and the next test reuses the
+    // already-closed socket — write succeeds into the kernel buffer, read in
+    // parseHTTPHeader blocks until SocketTimeoutException. See ReportTest flake on CI.
+    System.setProperty("http.keepAlive", "false");
+  }
+
   protected static final WireMockServer wireMock = new WireMockServer(0);
   private static final Logger LOG = LoggerFactory.getLogger(BaseUITest.class);
   private final Logger log = LoggerFactory.getLogger(getClass());
@@ -71,9 +81,18 @@ public class BaseUITest {
       log.info("Started AUT at {}", Configuration.baseUrl);
 
       long startTime = currentTimeMillis();
-      byte[] html = toByteArray(new URL(Configuration.baseUrl));
-      log.info("Loaded AUT welcome page from {} in {} ms. ({} bytes)",
-          Configuration.baseUrl, currentTimeMillis() - startTime, html.length);
+      URL warmupUrl = new URL(Configuration.baseUrl);
+      HttpURLConnection connection = (HttpURLConnection) warmupUrl.openConnection();
+      connection.setUseCaches(false);
+      connection.setRequestProperty("Connection", "close");
+      try (InputStream in = connection.getInputStream()) {
+        byte[] html = in.readAllBytes();
+        log.info("Loaded AUT welcome page from {} in {} ms. ({} bytes)",
+            warmupUrl, currentTimeMillis() - startTime, html.length);
+      }
+      finally {
+        connection.disconnect();
+      }
     } else {
       log.info("Running AUT on {}", Configuration.baseUrl);
     }


### PR DESCRIPTION
ReportTest flaked on CI because HttpURLConnection's KeepAliveCache retained an idle TCP socket that the JDK httpserver silently closed after sun.net.httpserver.idleInterval (30 s by default). The next test reused the dead socket; the write went into the kernel buffer and the read in parseHTTPHeader blocked until pdftest's read timeout fired (~10 s).

Three orthogonal mitigations:
- BaseUITest sets http.keepAlive=false, eliminating the client cache.
- The warmup GET in startAUT() now uses an explicit HttpURLConnection with setUseCaches(false), Connection: close, and disconnect() in finally — no idle socket leaves startAUT().
- javanet Server raises sun.net.httpserver.idleInterval to 600 s (override-friendly), so even if a caller leaves keep-alive enabled the server stops closing sockets mid-test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted server HTTP idle timeout handling to prevent premature connection closures and improve keep-alive reliability.

* **Tests**
  * Improved test startup and connection handling by disabling reuse of stale HTTP connections and ensuring explicit connection cleanup for more consistent test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->