### PR TITLE
feat: support chunked responses in javanet (fix #570)

### DIFF
--- a/javanet/src/play/server/javanet/PlayHandler.java
+++ b/javanet/src/play/server/javanet/PlayHandler.java
@@ -104,6 +104,9 @@ public class PlayHandler implements HttpHandler {
       response.out = new ByteArrayOutputStream();
       response.direct = null;
 
+      final Http.Request finalRequest = request;
+      response.onWriteChunk(chunk -> writeChunk(exchange, finalRequest, response, chunk));
+
       boolean raw =
           Play.pluginCollection.rawInvocation(
               request, response, null, Scope.RenderArgs.current(), null);
@@ -142,13 +145,13 @@ public class PlayHandler implements HttpHandler {
         fileService.serve(file, exchange, request, response, keepAlive);
       }
     } else if (is != null) {
-      if (!exchange.getRequestMethod().equals(HEAD) && exchange.getResponseCode() != NOT_MODIFIED) {
-        // writeFuture = ctx.getChannel().write(new ChunkedStream(is));
+      if (!exchange.getRequestMethod().equals(HEAD) && response.status != NOT_MODIFIED) {
+        exchange.sendResponseHeaders(response.status, 0);
+        try (OutputStream responseBody = exchange.getResponseBody()) {
+          IOUtils.copy(is, responseBody);
+        }
       } else {
         is.close();
-      }
-      if (!keepAlive) {
-        // writeFuture.addListener(ChannelFutureListener.CLOSE);
       }
     } else {
       writeResponse(exchange, request, response);
@@ -287,6 +290,29 @@ public class PlayHandler implements HttpHandler {
     }
 
     logger.trace("writeResponse: end :{}:{}", request.method, request.path);
+  }
+
+  private void writeChunk(
+      HttpExchange exchange, Http.Request request, Http.Response response, Object chunk) {
+    try {
+      if (exchange.getResponseCode() == -1) {
+        sendContentType(exchange, response);
+        addToResponse(exchange, response);
+        exchange.sendResponseHeaders(response.status, 0);
+      }
+      byte[] bytes;
+      if (chunk instanceof byte[]) {
+        bytes = (byte[]) chunk;
+      } else {
+        String message = chunk == null ? "" : chunk.toString();
+        bytes = message.getBytes(response.encoding);
+      }
+      OutputStream out = exchange.getResponseBody();
+      out.write(bytes);
+      out.flush();
+    } catch (IOException e) {
+      logger.error("Error writing chunk :{}:{}", request.method, request.path, e);
+    }
   }
 
   private void addETag(HttpExchange exchange, File file) throws IOException {
@@ -441,7 +467,11 @@ public class PlayHandler implements HttpHandler {
     public void onSuccess() throws Exception {
       super.onSuccess();
       logger.trace("onSuccess: begin :{}:{}", request.method, request.path);
-      copyResponse(exchange, request, response);
+      if (response.chunked) {
+        exchange.getResponseBody().close();
+      } else {
+        copyResponse(exchange, request, response);
+      }
       logger.trace("onSuccess: end :{}:{}", request.method, request.path);
     }
   }

--- a/javanet/src/play/server/javanet/PlayHandler.java
+++ b/javanet/src/play/server/javanet/PlayHandler.java
@@ -145,13 +145,15 @@ public class PlayHandler implements HttpHandler {
         fileService.serve(file, exchange, request, response, keepAlive);
       }
     } else if (is != null) {
-      if (!exchange.getRequestMethod().equals(HEAD) && response.status != NOT_MODIFIED) {
-        exchange.sendResponseHeaders(response.status, 0);
-        try (OutputStream responseBody = exchange.getResponseBody()) {
-          IOUtils.copy(is, responseBody);
+      try (InputStream inputStream = is) {
+        if (!exchange.getRequestMethod().equals(HEAD) && response.status != NOT_MODIFIED) {
+          exchange.sendResponseHeaders(response.status, 0);
+          try (OutputStream responseBody = exchange.getResponseBody()) {
+            IOUtils.copy(inputStream, responseBody);
+          }
+        } else {
+          exchange.sendResponseHeaders(response.status, -1);
         }
-      } else {
-        is.close();
       }
     } else {
       writeResponse(exchange, request, response);

--- a/netty4/src/play/server/netty4/PlayHandler.java
+++ b/netty4/src/play/server/netty4/PlayHandler.java
@@ -793,12 +793,21 @@ public class PlayHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
         // its encoder would immediately write the terminating "0\r\n\r\n" chunk.
         // Use DefaultHttpResponse (headers only) so subsequent DefaultHttpContent
         // writes carry the actual body chunks.
-        playResponse.setHeader("Transfer-Encoding", "chunked");
         playResponse.direct = "chunked";
         DefaultHttpResponse nettyResponse =
             new DefaultHttpResponse(HTTP_1_1, HttpResponseStatus.valueOf(playResponse.status));
         addToResponse(playResponse, nettyResponse);
+        // addToResponse may have copied a Content-Length or a stale Transfer-Encoding;
+        // strip both and re-assert chunked only for non-HEAD requests.
+        nettyResponse.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);
+        if (!nettyRequest.method().equals(HEAD)) {
+          nettyResponse.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
+          nettyResponse.headers().set(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+        }
         ctx.channel().writeAndFlush(nettyResponse);
+      }
+      if (nettyRequest.method().equals(HEAD)) {
+        return;
       }
       byte[] bytes;
       if (chunk instanceof byte[]) {

--- a/netty4/src/play/server/netty4/PlayHandler.java
+++ b/netty4/src/play/server/netty4/PlayHandler.java
@@ -51,6 +51,8 @@ import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.stream.ChunkedInput;
 import io.netty.handler.stream.ChunkedStream;
 import io.netty.handler.stream.ChunkedWriteHandler;
@@ -287,7 +289,7 @@ public class PlayHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
       super.onSuccess();
       logger.trace("onSuccess: begin :{}:{}", request.method, request.path);
       if (response.chunked) {
-        closeChunked(response);
+        closeChunked(response, ctx);
       } else {
         copyResponse(ctx, request, response, nettyRequest);
       }
@@ -787,30 +789,31 @@ public class PlayHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
       Object chunk) {
     try {
       if (playResponse.direct == null) {
+        // Mark that chunked streaming has started, but don't use FullHttpResponse —
+        // its encoder would immediately write the terminating "0\r\n\r\n" chunk.
+        // Use DefaultHttpResponse (headers only) so subsequent DefaultHttpContent
+        // writes carry the actual body chunks.
         playResponse.setHeader("Transfer-Encoding", "chunked");
-        playResponse.direct = new LazyChunkedInput();
-        copyResponse(ctx, playRequest, playResponse, nettyRequest);
+        playResponse.direct = "chunked";
+        DefaultHttpResponse nettyResponse =
+            new DefaultHttpResponse(HTTP_1_1, HttpResponseStatus.valueOf(playResponse.status));
+        addToResponse(playResponse, nettyResponse);
+        ctx.channel().writeAndFlush(nettyResponse);
       }
-      ((LazyChunkedInput) playResponse.direct).writeChunk(chunk, playResponse.encoding);
-
-      if (this.pipelines.get("ChunkedWriteHandler") != null) {
-        ((ChunkedWriteHandler) this.pipelines.get("ChunkedWriteHandler")).resumeTransfer();
+      byte[] bytes;
+      if (chunk instanceof byte[]) {
+        bytes = (byte[]) chunk;
+      } else {
+        String message = chunk == null ? "" : chunk.toString();
+        bytes = message.getBytes(playResponse.encoding);
       }
-      if (this.pipelines.get("SslChunkedWriteHandler") != null) {
-        ((ChunkedWriteHandler) this.pipelines.get("SslChunkedWriteHandler")).resumeTransfer();
-      }
+      ctx.channel().writeAndFlush(new DefaultHttpContent(Unpooled.wrappedBuffer(bytes)));
     } catch (Exception e) {
       throw new UnexpectedException(e);
     }
   }
 
-  private void closeChunked(Response playResponse) {
-    ((LazyChunkedInput) playResponse.direct).close();
-    if (this.pipelines.get("ChunkedWriteHandler") != null) {
-      ((ChunkedWriteHandler) this.pipelines.get("ChunkedWriteHandler")).resumeTransfer();
-    }
-    if (this.pipelines.get("SslChunkedWriteHandler") != null) {
-      ((ChunkedWriteHandler) this.pipelines.get("SslChunkedWriteHandler")).resumeTransfer();
-    }
+  private void closeChunked(Response playResponse, ChannelHandlerContext ctx) {
+    ctx.channel().writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
   }
 }

--- a/netty4/src/play/server/netty4/PlayHandler.java
+++ b/netty4/src/play/server/netty4/PlayHandler.java
@@ -289,7 +289,7 @@ public class PlayHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
       super.onSuccess();
       logger.trace("onSuccess: begin :{}:{}", request.method, request.path);
       if (response.chunked) {
-        closeChunked(response, ctx);
+        closeChunked(response, ctx, nettyRequest);
       } else {
         copyResponse(ctx, request, response, nettyRequest);
       }
@@ -813,7 +813,10 @@ public class PlayHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
     }
   }
 
-  private void closeChunked(Response playResponse, ChannelHandlerContext ctx) {
-    ctx.channel().writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+  private void closeChunked(Response playResponse, ChannelHandlerContext ctx, FullHttpRequest nettyRequest) {
+    ChannelFuture future = ctx.channel().writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+    if (!isKeepAlive(nettyRequest)) {
+      future.addListener(ChannelFutureListener.CLOSE);
+    }
   }
 }

--- a/replay-tests/helloworld/app/controllers/HelloWorld.java
+++ b/replay-tests/helloworld/app/controllers/HelloWorld.java
@@ -13,6 +13,7 @@ import play.data.validation.Validation;
 import play.modules.pdf.PdfResult;
 import play.mvc.Controller;
 import play.mvc.results.BadRequest;
+import play.mvc.results.NoResult;
 import play.rebel.View;
 
 public class HelloWorld extends Controller {
@@ -62,5 +63,12 @@ public class HelloWorld extends Controller {
 
   public View empty() {
     return new View();
+  }
+
+  public NoResult chunked() {
+    response.writeChunk("first chunk\n");
+    response.writeChunk("second chunk\n");
+    response.writeChunk("third chunk\n");
+    return new NoResult();
   }
 }

--- a/replay-tests/helloworld/conf/routes
+++ b/replay-tests/helloworld/conf/routes
@@ -8,6 +8,7 @@ GET    /pdf                HelloWorld.helloPdf
 GET    /pdf/text           HelloWorld.helloPdfFromPlainText
 GET    /pdf/text2          HelloWorld.helloPdfUsingRequestFormat
 GET    /empty              HelloWorld.empty
+GET    /chunked            HelloWorld.chunked
 POST   /post               AcceptPost.respondWithSameObject
 
 GET     /public/           staticDir:app/public

--- a/replay-tests/helloworld/test/ui/hello/ChunkedResponseSpec.java
+++ b/replay-tests/helloworld/test/ui/hello/ChunkedResponseSpec.java
@@ -1,0 +1,23 @@
+package ui.hello;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+
+public class ChunkedResponseSpec extends BaseSpec {
+
+  @Test
+  public void chunkedResponse() {
+    when()
+        .get("/chunked")
+        .then()
+        .log()
+        .ifValidationFails()
+        .statusCode(200)
+        .header("Transfer-Encoding", equalTo("chunked"))
+        .header("Content-Length", nullValue())
+        .body(equalTo("first chunk\nsecond chunk\nthird chunk\n"));
+  }
+}


### PR DESCRIPTION
## Summary

- **javanet**: implements chunked response support — registers an `onWriteChunk` handler that calls `sendResponseHeaders(status, 0)` on the first chunk (JDK `HttpServer` activates `Transfer-Encoding: chunked` when length=0), then writes and flushes each chunk to the exchange output stream; `onSuccess()` closes the stream when `response.chunked` is true. Also fixes the previously dead `InputStream` branch in `copyResponse()`.
- **netty4**: fixes a pre-existing bug where `writeChunk()` used `DefaultFullHttpResponse`, whose HTTP encoder immediately writes the terminating `0\r\n\r\n` chunk, producing an empty body. Now uses `DefaultHttpResponse` (headers only) + `DefaultHttpContent` per chunk + `LastHttpContent.EMPTY_LAST_CONTENT` to close.
- **helloworld**: adds a `/chunked` endpoint and `ChunkedResponseSpec` integration test that runs against all three backends (netty3, netty4, javanet) via the existing `uitest-*` task matrix.

Closes #570

## Test plan

- [x] `./gradlew :javanet:test` — unit tests pass
- [x] `./gradlew :replay-tests:helloworld:uitest` — `ChunkedResponseSpec` passes on netty3, netty4, and javanet
- [x] Full `uitest` suite shows no regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for chunked HTTP responses, enabling streamed multi-part bodies.
  * Added a new `/chunked` sample endpoint that returns three streamed chunks.
* **Bug Fixes**
  * Improved chunked/streamed response behavior to correctly set `Transfer-Encoding: chunked` and omit `Content-Length` where appropriate.
  * Enhanced chunk writing and termination handling across Play server implementations.
* **Tests**
  * Added a UI test covering `/chunked`, asserting headers and exact streamed body content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->