### PR TITLE
test: add integration tests for uncovered Groovy template tags

### DIFF
--- a/replay-tests/helloworld/app/controllers/HelloWorld.java
+++ b/replay-tests/helloworld/app/controllers/HelloWorld.java
@@ -11,6 +11,7 @@ import play.data.validation.Min;
 import play.data.validation.Valid;
 import play.data.validation.Validation;
 import play.modules.pdf.PdfResult;
+import org.jspecify.annotations.Nullable;
 import play.mvc.Controller;
 import play.mvc.results.BadRequest;
 import play.mvc.results.NoResult;
@@ -76,7 +77,7 @@ public class HelloWorld extends Controller {
     return new View("tags.html", ImmutableMap.of("n", 2));
   }
 
-  public View tagForm(String username) {
+  public View tagForm(@Nullable String username) {
     if (username == null || username.isEmpty()) {
       Validation.addError("username", "required");
     }

--- a/replay-tests/helloworld/app/controllers/HelloWorld.java
+++ b/replay-tests/helloworld/app/controllers/HelloWorld.java
@@ -71,4 +71,15 @@ public class HelloWorld extends Controller {
     response.writeChunk("third chunk\n");
     return new NoResult();
   }
+
+  public View tags() {
+    return new View("tags.html", ImmutableMap.of("n", 2));
+  }
+
+  public View tagForm(String username) {
+    if (username == null || username.isEmpty()) {
+      Validation.addError("username", "required");
+    }
+    return new View("tag-form.html");
+  }
 }

--- a/replay-tests/helloworld/app/views/tag-form.html
+++ b/replay-tests/helloworld/app/views/tag-form.html
@@ -1,0 +1,14 @@
+<html>
+<body>
+#{field 'username'}
+<p id="field-name">${field.name}</p>
+<p id="field-error-class">${field.errorClass}</p>
+#{/field}
+
+#{ifError 'username'}<p id="if-error">has-error</p>#{/ifError}
+
+<p id="error-class">#{errorClass 'username' /}</p>
+
+<p id="error-msg">#{error 'username' /}</p>
+</body>
+</html>

--- a/replay-tests/helloworld/app/views/tag-form.html
+++ b/replay-tests/helloworld/app/views/tag-form.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <body>
 #{field 'username'}

--- a/replay-tests/helloworld/app/views/tag-partial.html
+++ b/replay-tests/helloworld/app/views/tag-partial.html
@@ -1,0 +1,1 @@
+<p id="render-result">${who}</p>

--- a/replay-tests/helloworld/app/views/tags.html
+++ b/replay-tests/helloworld/app/views/tags.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <body>
 #{set title:'Tags test'/}

--- a/replay-tests/helloworld/app/views/tags.html
+++ b/replay-tests/helloworld/app/views/tags.html
@@ -1,0 +1,22 @@
+<html>
+<body>
+#{set title:'Tags test'/}
+<p id="set-get">#{get 'title' /}</p>
+
+#{ifnot false}<p id="ifnot">visible</p>#{/ifnot}
+
+#{if n == 1}<p id="elseif">one</p>#{/if}#{elseif n == 2}<p id="elseif">two</p>#{/elseif}#{else}<p id="elseif">other</p>#{/else}
+
+#{render 'tag-partial.html', who:'Rendered' /}
+
+#{cache 'tags-test', for:'1s'}<p id="cache">cached</p>#{/cache}
+
+<p id="jsaction">#{jsAction @HelloWorld.hello(':greeting') /}</p>
+
+<p id="sij">#{secureInlineJavaScript}inline-js#{/secureInlineJavaScript}</p>
+
+<p id="jsroute">#{jsRoute @HelloWorld.hello() /}</p>
+
+#{a @AcceptPost.respondWithSameObject()}<span id="a-tag">post-link</span>#{/a}
+</body>
+</html>

--- a/replay-tests/helloworld/conf/routes
+++ b/replay-tests/helloworld/conf/routes
@@ -9,6 +9,8 @@ GET    /pdf/text           HelloWorld.helloPdfFromPlainText
 GET    /pdf/text2          HelloWorld.helloPdfUsingRequestFormat
 GET    /empty              HelloWorld.empty
 GET    /chunked            HelloWorld.chunked
+GET    /tags               HelloWorld.tags
+GET    /tag-form           HelloWorld.tagForm
 POST   /post               AcceptPost.respondWithSameObject
 
 GET     /public/           staticDir:app/public

--- a/replay-tests/helloworld/test/ui/hello/TemplateTagsSpec.java
+++ b/replay-tests/helloworld/test/ui/hello/TemplateTagsSpec.java
@@ -2,6 +2,7 @@ package ui.hello;
 
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +20,12 @@ public class TemplateTagsSpec extends BaseSpec {
 
   @Test
   public void elseif_tag() {
-    when().get("/tags").then().statusCode(200).body(containsString("two"));
+    when()
+        .get("/tags")
+        .then()
+        .statusCode(200)
+        .body(containsString("<p id=\"elseif\">two</p>"))
+        .body(not(containsString("<p id=\"elseif\">one</p>")));
   }
 
   @Test
@@ -63,8 +69,8 @@ public class TemplateTagsSpec extends BaseSpec {
         .get("/tag-form")
         .then()
         .statusCode(200)
-        .body(containsString("username"))
-        .body(containsString("hasError"));
+        .body(containsString("<p id=\"field-name\">username</p>"))
+        .body(containsString("<p id=\"field-error-class\">hasError</p>"));
   }
 
   @Test

--- a/replay-tests/helloworld/test/ui/hello/TemplateTagsSpec.java
+++ b/replay-tests/helloworld/test/ui/hello/TemplateTagsSpec.java
@@ -1,0 +1,84 @@
+package ui.hello;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+public class TemplateTagsSpec extends BaseSpec {
+
+  @Test
+  public void set_and_get_tag() {
+    when().get("/tags").then().statusCode(200).body(containsString("Tags test"));
+  }
+
+  @Test
+  public void ifnot_tag() {
+    when().get("/tags").then().statusCode(200).body(containsString("visible"));
+  }
+
+  @Test
+  public void elseif_tag() {
+    when().get("/tags").then().statusCode(200).body(containsString("two"));
+  }
+
+  @Test
+  public void render_tag() {
+    when().get("/tags").then().statusCode(200).body(containsString("Rendered"));
+  }
+
+  @Test
+  public void cache_tag() {
+    when().get("/tags").then().statusCode(200).body(containsString("cached"));
+  }
+
+  @Test
+  public void jsAction_tag() {
+    when().get("/tags").then().statusCode(200).body(containsString("function(options)"));
+  }
+
+  @Test
+  public void secureInlineJavaScript_tag() {
+    when().get("/tags").then().statusCode(200).body(containsString("inline-js"));
+  }
+
+  @Test
+  public void jsRoute_tag() {
+    when().get("/tags").then().statusCode(200).body(containsString("url:"));
+  }
+
+  @Test
+  public void a_tag() {
+    when()
+        .get("/tags")
+        .then()
+        .statusCode(200)
+        .body(containsString("style=\"display:none\""))
+        .body(containsString("post-link"));
+  }
+
+  @Test
+  public void field_tag() {
+    when()
+        .get("/tag-form")
+        .then()
+        .statusCode(200)
+        .body(containsString("username"))
+        .body(containsString("hasError"));
+  }
+
+  @Test
+  public void ifError_tag() {
+    when().get("/tag-form").then().statusCode(200).body(containsString("has-error"));
+  }
+
+  @Test
+  public void errorClass_tag() {
+    when().get("/tag-form").then().statusCode(200).body(containsString("hasError"));
+  }
+
+  @Test
+  public void error_tag() {
+    when().get("/tag-form").then().statusCode(200).body(containsString("required"));
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `TemplateTagsSpec` with 13 integration tests covering tags that had no uitest coverage before
- New templates: `tags.html` (covers `ifnot`, `elseif`, `else`, `set`, `get`, `render`, `cache`, `jsAction`, `secureInlineJavaScript`, `jsRoute`, `a`) and `tag-form.html` (covers `field`, `ifError`, `errorClass`, `error`)
- New partial `tag-partial.html` for the `#{render}` test

## Test plan

- [x] `./gradlew :replay-tests:helloworld:uitest-netty4 --tests 'ui.hello.TemplateTagsSpec'` — all 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new pages for tag examples and a simple username form.
  * Introduced additional template rendering on the demo site, including conditional content, partials, caching, and JavaScript-related output.

* **Bug Fixes**
  * Improved form handling by showing validation feedback when the username is missing or blank.

* **Tests**
  * Added end-to-end UI coverage for the new pages and template behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->